### PR TITLE
Update x86_toolchain.sh

### DIFF
--- a/scripts/x86_toolchain.sh
+++ b/scripts/x86_toolchain.sh
@@ -3,7 +3,8 @@
 # Created by Lubos Kuzma
 # ISS Program, SADT, SAIT
 # August 2022
-
+#edits by Saiban: 64-bit is always True
+echo -e "\n***Toolchain will operate only in 64-bit mode***\n"
 
 if [ $# -lt 1 ]; then
         echo "Usage:"
@@ -25,7 +26,7 @@ POSITIONAL_ARGS=()
 GDB=False
 OUTPUT_FILE=""
 VERBOSE=False
-BITS=False
+BITS=True
 QEMU=False
 BREAK="_start"
 RUN=False
@@ -44,10 +45,10 @@ while [[ $# -gt 0 ]]; do
                         VERBOSE=True
                         shift # past argument
                         ;;
-                -64|--x84-64)
-                        BITS=True
-                        shift # past argument
-                        ;;
+             #   -64|--x84-64)        /// 64-bit mode is default
+              #          BITS=True
+               #         shift # past argument
+                #        ;;
                 -q|--qemu)
                         QEMU=True
                         shift # past argument


### PR DESCRIPTION
64-bit is always on and can be easily switched back to user input.